### PR TITLE
Experiment with supporting full-body query functions

### DIFF
--- a/lib/ecto_function/body_builder.ex
+++ b/lib/ecto_function/body_builder.ex
@@ -1,0 +1,45 @@
+defmodule EctoFunction.BodyBuilder do
+  def build(ast, params) do
+    params = Enum.map(params, &extract_arg/1)
+    {fragment, args} = build_fragment(ast, params)
+
+    quote bind_quoted: [args: [fragment | args]] do
+      quote do: fragment(unquote_splicing(args))
+    end
+  end
+
+  defp build_fragment({:cond, _env, [[do: cases]]}, params) do
+    {fragment, args} = condition_fragment(cases, params, [], [])
+
+    {"CASE #{fragment} END", args}
+  end
+
+  defp condition_fragment([], _, fragment, args),
+    do: {Enum.reverse(fragment), Enum.reverse(args)}
+
+  defp condition_fragment([{:->, _, [[true], result]}], params, fragment, args) do
+  result = unquote_params(result, params)
+    condition_fragment([], params, [" ELSE ?" | fragment], [Macro.escape(result, unquote: true) | args])
+  end
+
+  defp condition_fragment([{:->, _env, [[condition], result]} | rest], params, fragment, args) do
+  condition = unquote_params(condition, params)
+  result = unquote_params(result, params)
+    condition_fragment(rest, params, [" WHEN ? THEN ?" | fragment], [Macro.escape(result, unquote: true), Macro.escape(condition, unquote: true)] ++ args)
+  end
+
+  defp unquote_params(ast, params) do
+    Macro.postwalk(ast, fn
+      {name, _, atom} = entry when is_atom(atom) ->
+      if name in params do
+        {:unquote, [], [entry]}
+      else
+        entry
+      end
+    other -> other
+    end)
+  end
+
+  defp extract_arg({:\\, _, [{name, _, _}, _]}), do: name
+  defp extract_arg({name, _, _}), do: name
+end


### PR DESCRIPTION
For now `cond` statements are supported, but it can uncleanly fail if there is unsupported construct in the query function body.

Up to discussion:

- [ ] maybe support some of the `case`s (with the constants as the match patters) as [PostgreSQL supports such construct](https://postgresql.org/docs/13/interactive/functions-conditional.html#FUNCTIONS-CASE)
- [ ] `if` and `unless`, but it will make them work slightly different from the Elixir one, as PostgreSQL is statically typed, so there is no way to simulate it for non-bool condition
- [ ] variables assignment? I am not even sure how that could work at all, but if someone have any idea, then I will be open

Things needed to be done before merging:

- [ ] Tests, extensive test suite
- [ ] Clean handling of invalid function body